### PR TITLE
API design： 注册应为POST /users

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -66,25 +66,7 @@ Code | msg      |
             "data": null
         }
 
-## User [/users/{username}]
-
-### Retrieve User Info [GET]
-
-+ Response 200 (application/json)
-
-        {
-            "msg": "OK",
-            "data": {
-                "username":"user"
-            }
-        }
-
-+ Response 403 (application/json)
-
-        {
-            "msg": "Forbidden",
-            "data": null
-        }
+## Register [/users]
 
 ### Register New User [POST]
 
@@ -108,6 +90,26 @@ Code | msg      |
 
         {
             "msg": "Conflict",
+            "data": null
+        }
+
+## User [/users/{username}]
+
+### Retrieve User Info [GET]
+
++ Response 200 (application/json)
+
+        {
+            "msg": "OK",
+            "data": {
+                "username":"user"
+            }
+        }
+
++ Response 403 (application/json)
+
+        {
+            "msg": "Forbidden",
             "data": null
         }
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -19,10 +19,10 @@ Code | msg      |
 
 ### Login [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username":"user",
+            "username":"example@mail2.sysu.edu.cn",
             "password":"pass",
         }
 
@@ -31,7 +31,7 @@ Code | msg      |
         {
             "msg": "OK",
             "data": {
-                "username": "user"
+                "userId": "a1b2c3d4e5"
             }
         }
 
@@ -46,10 +46,10 @@ Code | msg      |
 
 ### Logout [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username": "user",
+            "userId": "a1b2c3d4e5",
         }
 
 + Response 200 (application/json)
@@ -70,10 +70,10 @@ Code | msg      |
 
 ### Register New User [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username": "user",
+            "username":"example@mail2.sysu.edu.cn",
             "password": "pass"
         }
 
@@ -82,7 +82,7 @@ Code | msg      |
         {
             "msg":"OK",
             "data": {
-                "username": "user"
+                "userId": "a1b2c3d4e5"
             }
         }
 
@@ -102,7 +102,7 @@ Code | msg      |
         {
             "msg": "OK",
             "data": {
-                "username":"user"
+                "userId":"a1b2c3d4e5"
             }
         }
 
@@ -115,10 +115,10 @@ Code | msg      |
 
 ### Modify User Info(PUT) [PUT]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username":"user",
+            "username":"example@mail2.sysu.edu.cn",
             "email": "example@example.com",
             "tel": "13322228888"
         }
@@ -129,7 +129,7 @@ Code | msg      |
             "msg":"OK",
             "data":
                     {
-                        "username":"user",
+                        "userId":"a1b2c3d4e5",
                         "email": "example@example.com",
                         "tel": "13322228888"
                     }
@@ -144,10 +144,10 @@ Code | msg      |
 
 ### Modify User Info(PATCH) [PATCH]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username":"user",
+            "userId":"a1b2c3d4e5",
             "email": "example2@example.com",
         }
 
@@ -157,8 +157,8 @@ Code | msg      |
             "msg":"OK",
             "data":
                     {
-                        "username":"user",
-                        "email": "example2@example.com",
+                        "userId":"a1b2c3d4e5",
+                        "email": "example@mail2.sysu.edu.cn",
                         "tel": "13322228888"
                     }
         }
@@ -172,10 +172,10 @@ Code | msg      |
 
 ### Delete a user [DELETE]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
-            "username": "user",
+            "username":"example@mail2.sysu.edu.cn",
             "password": "pass"
         }
 
@@ -246,7 +246,7 @@ Code | msg      |
 
 ### Create a new post [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
             "username": "user",
@@ -336,7 +336,7 @@ Code | msg      |
 
 ### Report a post [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
             "reason": "report reason text string"
@@ -436,7 +436,7 @@ Code | msg      |
 
 ### Comment on a post [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
             "comment": {
@@ -509,7 +509,7 @@ Code | msg      |
 
 ### Report a comment [POST]
 
-+ Request (application/x-www-form-urlencoded)
++ Request (application/json)
 
         {
             "reason": "report reason text string"

--- a/standard-api-doc.md
+++ b/standard-api-doc.md
@@ -1,0 +1,137 @@
+# 标准API文档
+
+- [登陆](#登陆)
+- [获取指定帖子(集合)](#获取指定帖子(集合))
+- [帖子评论](#帖子评论)
+
+## 登陆
+
+### 应用场景
+
+用户使用树洞就必须登录，否则无法使用包括浏览在内的任何功能。
+
+### 接口链接
+
+POST https://api.shudong.cn/login
+
+### 请求参数
+
+变量名      | 必填 | 类型 | 示例值 | 描述 |
+-------  | ------ | ---- | ----| ---- |
+username | Y | String(32) | example_username | 用户名 |
+password | Y | String(128) | example_password | 密码 |
+
+举例如下：
+
+```text
+username=example_username&password=example_passwd
+```
+
+### 返回结果
+
+变量名 | 必填 | 类型 | 示例值 | 描述 |
+----  | ------ | ---- | ---- | ---- |
+msg | Y | String(32) | OK | HTTP Response Code对应的信息 |
+data | Y | Object | {"username":"user"} | 包含当前用户信息 |
+
+当登录失败时， `data`为`null`。
+
+### 错误码
+
+名称 | 描述 | 原因 | 解决方案 |
+---- | ---- | ---- | ---- |
+Unauthorized | 未授权 | 登录失败，用户名或密码错误 | 检查用户名和密码 |
+Internal Server Error | 中间服务器出错 | 网络环境出现问题 | 检查网络问题 |
+
+## 获取指定帖子(集合)
+
+### 应用场景
+
+用户进入广场页面之后：需要获取并显示最近的帖子，或是按照一定的条件进行搜索
+
+### 接口链接
+
+URL地址： GET https://api.shudong.cn/posts
+
+### 请求参数
+
+变量名      | 必填 | 类型 | 示例值 | 描述 |
+-------  | ------ | ---- | ----| ---- |
+postid  | N | Int | 2 | 选择指定postid的帖子。当有效指定此参数时，其他参数均被忽略。(即对/posts/{postId}的简单重复) |
+limit  | N | Int | 10 | 限制一次最多返回posts的数量，默认为10 |
+offset  | N | Int | 10 | 配合limit使用，设置从第几条查询结果开始返回，缺省为0 |
+
+举例如下：
+
+```text
+GET https://api.shudong.cn/posts?limit=15&offset=10
+GET https://api.shudong.cn/posts?postid=3
+```
+
+### 返回结果
+
+变量名 | 必填 | 类型 | 示例值 | 描述 |
+----  | ------ | ---- | ---- | ---- |
+msg | Y | String(32) | OK | HTTP Response Code对应的信息 |
+data | Y | Array\<Object\> | [{"postId":1,"author":"test", ...}, ...] | 符合查询条件的posts的Object数组
+
+当msg不为2xx(HTTP状态码)对应的信息时，`data`均为`null`
+
+### 错误码
+
+名称 | 描述 | 原因 | 解决方案 |
+---- | ---- | ---- | ---- |
+Unauthorized | 未授权 | 用户未登陆 | 提示用户登录 |
+Internal Server Error | 中间服务器出错 | 网络环境出现问题 | 检查网络问题 |
+
+## 帖子评论
+
+### 应用场景
+
+打开一个帖子之后，在帖子下方进行评论。
+
+### 接口链接
+
+POST https://api.shudong.cn/posts/{postid}/comments
+
+### 请求参数
+
+变量名      | 必填 | 类型 | 示例值 | 描述 |
+-------  | ------ | ---- | ----| ---- |
+content  | Y | String | "example comment" | 评论内容 |
+
+参数用json转义即可。举例如下：
+
+```json
+{ "content": "new example comment" }
+```
+
+### 返回结果
+
+变量名 | 必填 | 类型 | 示例值 | 描述 |
+----  | ------ | ---- | ---- | ---- |
+msg | Y | String(32) | OK | HTTP Response Code对应的信息 |
+data | Y | Object | (见下方) | 包含当前用户信息 |
+
+当msg不为2xx(HTTP状态码)对应的信息时，`data`均为`null`。
+
+反之，当状态码为`2xx`时，data将是一个Object，其包含的属性值如下：
+
+变量名 | 必填 | 类型 | 示例值 | 描述 |
+----  | ------ | ---- | ---- | ---- |
+commentId | Y | Int | 17 | 该新生成的评论的commentId |
+author | Y | Object | (见下方) | 包含当前用户信息 |
+relatedPostId | Y | Int | 3 | 该条评论与哪一条post相关 |
+content | Y | String | "example content" | 新生成的评论的内容 |
+like_count | Y | Int | 7 | 当前有多少人给这条评论点赞
+
+### 错误码
+
+名称 | 描述 | 原因 | 解决方案 |
+---- | ---- | ---- | ---- |
+Unauthorized | 未授权 | 用户未登陆 | 提示用户登录 |
+Internal Server Error | 中间服务器出错 | 网络环境出现问题 | 检查网络问题 |
+
+### 系统顺序图
+
+![Comment](https://raw.githubusercontent.com/Chun-Ge/documents/master/docs/model-docs/system-sequence-diagram/15331302-comment.png)


### PR DESCRIPTION
用户注册模式确定为：使用中大邮箱注册、登陆， 每个用户有一个唯一的`userId`(用户无需在意)，由服务器自动生成并返回。后续的业务请求均以该`userId`作为用户标识（而不是作为用户名的中大邮箱地址）。

例如：
用户A以`example@mail2.sysu.edu.cn`注册之后，后台返回注册成功信息，同时返回注册成功时生成的该用户的`{'userId': a1b2c3d4e5}`，（登陆成功时也一样），后面访问用户信息的路由即为`/users/a1b2c3d4e5`。