### PR TITLE
add response wrappers

### DIFF
--- a/vendor/response/response.go
+++ b/vendor/response/response.go
@@ -1,0 +1,57 @@
+package response
+
+import (
+	"net/http"
+
+	"github.com/kataras/iris"
+)
+
+// OuterMsg : sturct of the response msg
+type OuterMsg struct {
+	Msg  string      `json:"msg"`
+	Data interface{} `json:"data"`
+}
+
+func genResponseMsg(messageCode int, data interface{}) *OuterMsg {
+	message := http.StatusText(messageCode)
+	return &OuterMsg{
+		Msg:  message,
+		Data: data,
+	}
+}
+
+// OK ..
+func OK(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusOK)
+	ctx.JSON(genResponseMsg(http.StatusOK, data))
+}
+
+// Created ..
+func Created(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusCreated)
+	ctx.JSON(genResponseMsg(http.StatusCreated, data))
+}
+
+// Unauthorized ..
+func Unauthorized(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusUnauthorized)
+	ctx.JSON(genResponseMsg(http.StatusUnauthorized, data))
+}
+
+// Forbidden ..
+func Forbidden(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusForbidden)
+	ctx.JSON(genResponseMsg(http.StatusForbidden, data))
+}
+
+// Conflict ..
+func Conflict(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusConflict)
+	ctx.JSON(genResponseMsg(http.StatusConflict, data))
+}
+
+// InternalServerError ..
+func InternalServerError(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusInternalServerError)
+	ctx.JSON(genResponseMsg(http.StatusInternalServerError, data))
+}


### PR DESCRIPTION
A new module `response` is created, wrapping `ctx.StatusCode()` and `ctx.JSON()` to provide much simpler methods for responses.

```go
import "response"
// ...
func exampleHandler(ctx iris.Context) {
    // retData can be any data type (interface{})
    var testID int64 = 3
    retData := model.GetPostByID(testID) // this time it will be *entity.Post
    response.OK(ctx, retData)
}
```