### PR TITLE
add CheckErrWithCallback()

### DIFF
--- a/vendor/err/err.go
+++ b/vendor/err/err.go
@@ -1,8 +1,27 @@
 package err
 
-// CheckErr .
+// Callback .
+type Callback func()
+
+// CheckErr checks if an error exists and calls panic() if so.
+//
+// Deprecated: Use CheckErrWithPanic() instead.
 func CheckErr(e error) {
 	if e != nil {
 		panic(e)
+	}
+}
+
+// CheckErrWithPanic is simply an alias of CheckErr(), to avoid unnecessary changes.
+// Use CheckErrWithPanic if panic() is needed.
+func CheckErrWithPanic(e error) {
+	CheckErr(e)
+}
+
+// CheckErrWithCallback checks if an error exists
+// and calls callback() if so.
+func CheckErrWithCallback(e error, callback Callback) {
+	if e != nil {
+		callback()
 	}
 }


### PR DESCRIPTION
```go
package err
// ...
type Callback func()
```
- add a function `CheckErrWithCallback(error, Callback)`
- add a function `CheckErrWithPanic(error)` which is an alias of `CheckErr(error)`
- `CheckErr(error)` is deprecated for its unclear name