### PR TITLE
init iris-configurations

### DIFF
--- a/config/sample.yml
+++ b/config/sample.yml
@@ -1,0 +1,6 @@
+DisablePathCorrection: false
+EnablePathEscape: false
+FireMethodNotAllowed: true
+DisableBodyConsumptionOnUnmarshal: true
+TimeFormat: Mon, 01 Jan 2006 15:04:05 GMT
+Charset: UTF-8

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	// _ "database"
 	"server"
 )
 
 func main() {
-	server.StartServer()
+	// server.Start()
+	server.StartWithConfiguration("./config/sample.yml")
 }

--- a/vendor/server/server.go
+++ b/vendor/server/server.go
@@ -8,10 +8,24 @@ import (
 	"github.com/kataras/iris"
 )
 
-// StartServer .
-func StartServer() {
+// Start .
+func Start() {
 	app := iris.New()
+
 	middlewares.Register(app)
 	route.Register(app)
+
+	app.Run(iris.Addr("" + args.Port))
+}
+
+// StartWithConfiguration reads the config file and
+func StartWithConfiguration(configFilePath string) {
+	app := iris.New()
+
+	middlewares.Register(app)
+	route.Register(app)
+
+	app.Configure(iris.WithConfiguration(iris.YAML(configFilePath)))
+
 	app.Run(iris.Addr("" + args.Port))
 }


### PR DESCRIPTION
Note: auto url escape is disabled. Consider using `net/url` or iris' auto url escape.