### PR TITLE
Middleware: check request JSON & set Response as JSON

### DIFF
--- a/vendor/middlewares/check_json.go
+++ b/vendor/middlewares/check_json.go
@@ -1,0 +1,31 @@
+package middlewares
+
+import (
+	"response"
+
+	"github.com/kataras/iris"
+)
+
+const (
+	jsonContentType string = "application/json"
+)
+
+// CheckContentTypeJSON ...
+func CheckContentTypeJSON(ctx iris.Context) {
+	if ctx.Method() != iris.MethodGet {
+		requestContentType := ctx.GetHeader("Content-Type")
+		if requestContentType != jsonContentType {
+			response.BadRequest(ctx, iris.Map{})
+			ctx.StopExecution()
+		}
+	}
+
+	ctx.Next()
+}
+
+// SetResponseContentTypeJSON ...
+func SetResponseContentTypeJSON(ctx iris.Context) {
+	ctx.ContentType(jsonContentType)
+
+	ctx.Next()
+}

--- a/vendor/middlewares/middlewares.go
+++ b/vendor/middlewares/middlewares.go
@@ -9,6 +9,10 @@ func Register(app *iris.Application) {
 	// register InternalErrorCatcher at the very beginning (before any middlewares/routes)
 	registerInternalErrorCatcher(app)
 
+	// register JSON data format check
+	// and set Response Content-Type = "application/json"
+	registerJSONCheck(app)
+
 	registerJwt(app)
 }
 
@@ -21,4 +25,9 @@ func registerJwt(app *iris.Application) {
 	// Check and parse JWT at the very beginning of each route,
 	// where the ContextKey field and "errjwt" field will be set.
 	app.Use(ServeJwt)
+}
+
+func registerJSONCheck(app *iris.Application) {
+	app.UseGlobal(CheckContentTypeJSON)
+	app.UseGlobal(SetResponseContentTypeJSON)
 }

--- a/vendor/response/callbacks.go
+++ b/vendor/response/callbacks.go
@@ -11,3 +11,11 @@ func GenCallbackInternalServerError(ctx iris.Context) func() {
 		InternalServerError(ctx, iris.Map{})
 	}
 }
+
+// GenCallbackBadRequest generates a callback func
+// which calls BadRequest() by passing null to data
+func GenCallbackBadRequest(ctx iris.Context) func() {
+	return func() {
+		BadRequest(ctx, iris.Map{})
+	}
+}

--- a/vendor/response/response.go
+++ b/vendor/response/response.go
@@ -32,6 +32,12 @@ func Created(ctx iris.Context, data interface{}) {
 	ctx.JSON(genResponseMsg(http.StatusCreated, data))
 }
 
+// BadRequest ...
+func BadRequest(ctx iris.Context, data interface{}) {
+	ctx.StatusCode(iris.StatusBadRequest)
+	ctx.JSON(genResponseMsg(http.StatusBadRequest, data))
+}
+
 // Unauthorized ...
 func Unauthorized(ctx iris.Context, data interface{}) {
 	ctx.StatusCode(iris.StatusUnauthorized)

--- a/vendor/service/comment.go
+++ b/vendor/service/comment.go
@@ -25,14 +25,11 @@ func CreateComment(ctx iris.Context) {
 	err.CheckErrWithPanic(er)
 
 	info := CommentInfo{UserID: userID, PostID: postID}
-	ctx.ReadJSON(&info)
+	er = ctx.ReadJSON(&info)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	comment, er := model.NewCommentWithRandomName(info.UserID, info.PostID, info.Comment.Content)
-
-	if er != nil {
-		response.InternalServerError(ctx, iris.Map{})
-		return
-	}
+	err.CheckErrWithPanic(er)
 
 	author, er := model.GetNameFromNameLibByID(comment.NameLibID)
 	err.CheckErrWithPanic(er)

--- a/vendor/service/post.go
+++ b/vendor/service/post.go
@@ -24,7 +24,9 @@ func CreatePost(ctx iris.Context) {
 	userID := middlewares.GetUserID(ctx)
 
 	info := &PostInfo{UserID: userID}
-	ctx.ReadJSON(info)
+	er := ctx.ReadJSON(info)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
+
 	post, er := model.NewPostWithRandomName(info.UserID, info.Post.CategoryID, info.Post.Title, info.Post.Content)
 	err.CheckErrWithPanic(er)
 

--- a/vendor/service/report_comment.go
+++ b/vendor/service/report_comment.go
@@ -25,7 +25,7 @@ func CreateReportComment(ctx iris.Context) {
 
 	info := ReportCommentInfo{UserID: userID, CommentID: commentID}
 	er = ctx.ReadJSON(&info)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	// TODO(alexandrali3): Check the existence of userID and commentID.
 

--- a/vendor/service/report_post.go
+++ b/vendor/service/report_post.go
@@ -25,7 +25,7 @@ func CreateReportPost(ctx iris.Context) {
 
 	info := ReportPostInfo{UserID: userID, PostID: postID}
 	er = ctx.ReadJSON(&info)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	// TODO(alexandrali3): Check the existence of userID and postID.
 

--- a/vendor/service/user.go
+++ b/vendor/service/user.go
@@ -58,7 +58,7 @@ func UserLogin(ctx iris.Context) {
 	userRequest := &UserRequestData{}
 
 	er := ctx.ReadJSON(userRequest)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	email := userRequest.Email
 	password := encodePassword(userRequest.Password)
@@ -94,7 +94,7 @@ func UserRegister(ctx iris.Context) {
 	userRequest := &UserRequestData{}
 
 	er := ctx.ReadJSON(userRequest)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	email := userRequest.Email
 	password := encodePassword(userRequest.Password)
@@ -124,7 +124,7 @@ func ChangePassword(ctx iris.Context) {
 	changePasswordRequest := &ChangePasswordRequestData{UserID: userID}
 
 	er := ctx.ReadJSON(changePasswordRequest)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	oldPassword := encodePassword(changePasswordRequest.OldPassword)
 	newPassword := encodePassword(changePasswordRequest.NewPassword)
@@ -149,7 +149,7 @@ func GenAuthCode(ctx iris.Context) {
 	genAuthCodeRequest := &GenAuthCodeRequestData{}
 
 	er := ctx.ReadJSON(genAuthCodeRequest)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	email := genAuthCodeRequest.Email
 
@@ -187,7 +187,7 @@ func ResetPassword(ctx iris.Context) {
 	info := &ResetPasswordRequestData{}
 
 	er := ctx.ReadJSON(info)
-	err.CheckErrWithPanic(er)
+	err.CheckErrWithCallback(er, response.GenCallbackBadRequest(ctx))
 
 	// check whether the email is valid
 	user, has, er := model.GetUserByEmail(info.Email)


### PR DESCRIPTION
Now a `Content-Type: application/json` is required in Request, and JSON format check is also added in each handler (from `service`) with non-GET methods. Now the server-side will send a `400 BadRequest` if either of the two requirements is un-satisfied.

Plus, I also add a middleware that set the `Content-Type` of Response as `application/json`.