### PR TITLE
responseHeader: Access-Control-Allow-Origin

### DIFF
--- a/vendor/middlewares/access_control_allow.go
+++ b/vendor/middlewares/access_control_allow.go
@@ -1,0 +1,12 @@
+package middlewares
+
+import (
+	"github.com/kataras/iris"
+)
+
+// SetAccessControlAllowOrigin ...
+func SetAccessControlAllowOrigin(ctx iris.Context) {
+	ctx.Header("Access-Control-Allow-Origin", "*")
+
+	ctx.Next()
+}

--- a/vendor/middlewares/middlewares.go
+++ b/vendor/middlewares/middlewares.go
@@ -9,6 +9,7 @@ func Register(app *iris.Application) {
 	// register JSON data format check
 	// and set Response Content-Type = "application/json"
 	registerJSONCheck(app)
+	registerXDomainSupport(app)
 
 	registerJwt(app)
 }
@@ -23,4 +24,8 @@ func registerJwt(app *iris.Application) {
 func registerJSONCheck(app *iris.Application) {
 	app.UseGlobal(CheckContentTypeJSON)
 	app.UseGlobal(SetResponseContentTypeJSON)
+}
+
+func registerXDomainSupport(app *iris.Application) {
+	app.UseGlobal(SetAccessControlAllowOrigin)
 }


### PR DESCRIPTION
暂时暴力把所有response里都加了`Access-Control-Allow-Origin`的Header。

`Access-Control-Allow-Origin: *`