### PR TITLE
Allow all x-domain request

### DIFF
--- a/vendor/middlewares/check_json.go
+++ b/vendor/middlewares/check_json.go
@@ -12,7 +12,8 @@ const (
 
 // CheckContentTypeJSON ...
 func CheckContentTypeJSON(ctx iris.Context) {
-	if ctx.Method() != iris.MethodGet {
+	if ctx.Method() != iris.MethodGet &&
+		ctx.Method() != iris.MethodOptions {
 		requestContentType := ctx.GetHeader("Content-Type")
 		if requestContentType != jsonContentType {
 			response.BadRequest(ctx, iris.Map{})

--- a/vendor/middlewares/middlewares.go
+++ b/vendor/middlewares/middlewares.go
@@ -9,7 +9,6 @@ func Register(app *iris.Application) {
 	// register JSON data format check
 	// and set Response Content-Type = "application/json"
 	registerJSONCheck(app)
-	registerXDomainSupport(app)
 
 	registerJwt(app)
 }
@@ -24,8 +23,4 @@ func registerJwt(app *iris.Application) {
 func registerJSONCheck(app *iris.Application) {
 	app.UseGlobal(CheckContentTypeJSON)
 	app.UseGlobal(SetResponseContentTypeJSON)
-}
-
-func registerXDomainSupport(app *iris.Application) {
-	app.UseGlobal(SetAccessControlAllowOrigin)
 }


### PR DESCRIPTION
我不熟悉后端的代码, 现在的做法是直接修改 route/route.go 里的 (私有) 注册函数的签名, 以引入 [cors](https://godoc.org/github.com/iris-contrib/middleware/cors) 对 Options 预请求的支持 ;